### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,45 +5,47 @@ This script is intended to be invoked via QjackCtl to start up and
 shut down JACK on a system running PulseAudio. It handles the
 necessary setup to make the two work together, so PulseAudio clients
 get transparently routed through JACK while the latter is running, or
-if pulseaudio is suspend by pasuspender, do nothing
+if PulseAudio is suspend by `pasuspender`, do nothing.
 
-Usage: in QjackCtl’s Settings window, in the “Options” tab, enter
+If you are using jack-dbus, and have `pulseaudio-module-jack` installed, 
+you already have a similar functionality and this script is not required.
+
+Usage: in QjackCtl’s “Setup” window, in the “Options” tab, enter
 the command
 
-pajackconnect start &
+`pajackconnect start &`
 
 in the field labelled “Execute script after Startup”, and put
 
-pajackconnect stop &
+`pajackconnect stop &`
 
 in the field labelled “Execute script on Shutdown”.
 
-pajackconnect reset &
+`pajackconnect reset &`
 
 in the field labelled “Execute script after Shutdown”.
 
-for use jack without pulseaudio, add in Qjackctl setting window 
-in the serverpath field 'pasuspender -- ' before 'jackd', save settings 
-as "No Pulse" for example. Remove 'pasuspender -- ', 
-and save settings as 'Pulse'. Now you can select from the 
-Qjackctl setting window, if you would start jack with or without pulse.
+For use JACK without PulseAudio: In QjackCtl's “Setup” window in the “Settings” tab 
+in the serverpath field  add `pasuspender -- ` before `jackd`, save settings 
+as “No Pulse” for example. Remove `pasuspender -- `, 
+and save settings as “Pulse”. Now you can select from the 
+QjackCtl Setup window, if you would start JACK with or without PulseAudio.
 
-To make it work after suspend, the file resume-fix-pulseaudio.service needs to be installed and enabled. 
+To make it work after suspend, the file `resume-fix-pulseaudio.service` needs to be installed and enabled. 
 If you use the debian package, the package installer handle that for you.
 
-DEBIAN:
+## DEBIAN:
 
 Build package with:
 ```
 dpkg-buildpackage -rfakeroot -uc -us -b
 ```
 On other distributions you need to first edit the file resume-fix-pulseaudio.service
-and replace USERNAME with your User name (logname) and USERID with your users ID (id -u $(logname))
+and replace `USERNAME` with your User name (logname) and `USERID` with your users ID (`id -u $(logname)`)
 
 after install you need to run (as root)
-
+```
 systemctl enable resume-fix-pulseaudio.service
-
 systemctl daemon-reload
-
+```
 to enable the service.


### PR DESCRIPTION
changed and conformed application names to their canonical spellings.
fixed markup for correct display on github
added note for users of jack-dbus
QjackCtl's settings dialog is actually called "Setup" and has a "Settings" tab