### PR TITLE
Add flag to prevent automatic connection of ports

### DIFF
--- a/pajackconnect
+++ b/pajackconnect
@@ -87,8 +87,9 @@ function restart() {
 			fi
 			# if jack is running and pulse jack modules aren't loaded,
 			# let's load them and set them as default ports
-			pacmd load-module module-jack-sink channels=2
-			pacmd load-module module-jack-source channels=2
+			[[ "$1" == "--no-auto-connect" ]] && no_auto_connect="connect=0" || no_auto_connect=""
+			pacmd load-module module-jack-sink channels=2 ${no_auto_connect}
+			pacmd load-module module-jack-source channels=2 ${no_auto_connect}
 			pacmd unload-module module-suspend-on-idle
 			pacmd set-default-sink jack_out
 			# move around source port, seems to make pulseaudio work with jack
@@ -121,8 +122,9 @@ function start() {
 		source=`pacmd list short sinks |  sed -n "/Default source name/p"| sed "s/Default source name://"`
 		echo $source >"$pajack_dir"/pasourcej
 		# load the pulseaudio jack module and set them as default ports
-		pacmd load-module module-jack-sink channels=2
-		pacmd load-module module-jack-source channels=2
+		[[ "$1" == "--no-auto-connect" ]] && no_auto_connect="connect=0" || no_auto_connect=""
+		pacmd load-module module-jack-sink channels=2 ${no_auto_connect}
+		pacmd load-module module-jack-source channels=2 ${no_auto_connect}
 		pacmd unload-module module-suspend-on-idle
 		pacmd set-default-sink jack_out
 		# move around source port, seems to make pulseaudio work with jack
@@ -171,10 +173,10 @@ function reset() {
 # check for given command-line option
 case "$1" in
 	restart)
-		restart
+		restart $2
 		;;
 	start)
-		start
+		start $2
 		;;
 	stop)
 		stop
@@ -183,7 +185,7 @@ case "$1" in
 		reset
 		;;
 	*)
-		echo $"Usage:\n\t $0 {restart|start|stop|reset}\n"
+		printf "Usage:\n\t $0 {restart|start|stop|reset} [--no-auto-connect]\n"
 		exit 1
 esac
 


### PR DESCRIPTION
Please consider this small change, which allows for creating the PA sink and source without automatically connecting them to the system. This is useful in scenarios where we want to use the QJackCtl patchbay, or a session manager, to automatically activate a custom routing.